### PR TITLE
Update Dependabot configuration for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,17 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv" # Update Python dependencies managed by uv
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dependencies:
         patterns:
           - "*"
 
-  # Example for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
Updates Dependabot configuration to work with the new uv package manager following the migration from pip-tools.

## Changes
- Added `enable-beta-ecosystems: true` to enable support for uv
- Changed package ecosystem from `"pip"` to `"uv"`
- Updated schedule from daily to weekly (matching GitHub Actions schedule)

## Context
This follows the successful migration to uv in #291. The configuration is based on the pattern used in https://github.com/Jakub3628800/pyproject-template.

## References
- [Dependabot uv support documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)
- Previous PR: #291 (Migrate to uv)

🤖 Generated with [Claude Code](https://claude.ai/code)