### PR TITLE
Refactor to use SQLAlchemy ORM models instead of raw SQL

### DIFF
--- a/shortener/actions.py
+++ b/shortener/actions.py
@@ -1,7 +1,12 @@
-import asyncpg
 import logging
 from typing import Dict, List, Any
+
+from sqlalchemy import select, delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
 from starlette.exceptions import HTTPException
+
+from shortener.models import ShortUrl
 
 
 class UrlNotFoundException(HTTPException):
@@ -16,23 +21,23 @@ class UrlValidationError(HTTPException):
         super().__init__(*args, **kwargs)
 
 
-async def check_db_up(connection: asyncpg.Connection) -> bool:
+async def check_db_up(session: AsyncSession) -> bool:
     """Check connectivity to the database."""
     try:
-        query_result = await connection.fetchval("SELECT 1;")
-        return query_result == 1
+        result = await session.execute(select(1))
+        return result.scalar() == 1
     except Exception as e:
         logging.error(f"Database connection error: {str(e)}")
         return False
 
 
-async def get_url_target(short_url: str, connection: asyncpg.Connection) -> str:
+async def get_url_target(short_url: str, session: AsyncSession) -> str:
     """
     Get the target URL for a given short URL key.
 
     Args:
         short_url: The short URL key to look up
-        connection: Database connection
+        session: Database session
 
     Returns:
         The target URL as a string
@@ -44,40 +49,42 @@ async def get_url_target(short_url: str, connection: asyncpg.Connection) -> str:
         raise UrlValidationError(detail="Short URL cannot be empty")
 
     try:
-        target = await connection.fetchval(
-            "SELECT target from short_urls where url_key=$1;", short_url
-        )
+        stmt = select(ShortUrl.target).where(ShortUrl.url_key == short_url)
+        result = await session.execute(stmt)
+        target = result.scalar_one_or_none()
+
         if target is None:
             raise UrlNotFoundException(detail=f"URL with key '{short_url}' not found")
         return target
-    except asyncpg.exceptions.PostgresError as e:
+    except UrlNotFoundException:
+        raise
+    except Exception as e:
         logging.error(f"Database error when retrieving URL: {str(e)}")
         raise HTTPException(status_code=500, detail="Database error")
-    except Exception as e:
-        logging.error(f"Unexpected error: {str(e)}")
-        raise UrlNotFoundException(detail=f"URL with key '{short_url}' not found")
 
 
-async def get_all_short_urls(connection: asyncpg.Connection) -> List[Dict[str, str]]:
+async def get_all_short_urls(session: AsyncSession) -> List[Dict[str, str]]:
     """
     Get all short URLs and their targets.
 
     Args:
-        connection: Database connection
+        session: Database session
 
     Returns:
         List of dictionaries containing short_url and target_url
     """
     try:
-        records = await connection.fetch("SELECT url_key, target from short_urls;")
-        return [{"short_url": record["url_key"], "target_url": record["target"]} for record in records]
+        stmt = select(ShortUrl.url_key, ShortUrl.target)
+        result = await session.execute(stmt)
+        records = result.all()
+        return [{"short_url": record.url_key, "target_url": record.target} for record in records]
     except Exception as e:
         logging.error(f"Error retrieving all URLs: {str(e)}")
         raise HTTPException(status_code=500, detail="Error retrieving URLs")
 
 
 async def create_url_target(
-    short_url: str, target_url: str, connection: asyncpg.Connection
+    short_url: str, target_url: str, session: AsyncSession
 ) -> bool:
     """
     Create a new short URL mapping.
@@ -85,7 +92,7 @@ async def create_url_target(
     Args:
         short_url: The short URL key to create
         target_url: The target URL it should redirect to
-        connection: Database connection
+        session: Database session
 
     Returns:
         True if successful, False if URL already exists
@@ -100,21 +107,21 @@ async def create_url_target(
         raise UrlValidationError(detail="Target URL cannot be empty")
 
     try:
-        await connection.execute(
-            "INSERT INTO short_urls (url_key, target) VALUES ($1,$2);",
-            short_url,
-            target_url,
-        )
+        new_url = ShortUrl(url_key=short_url, target=target_url)
+        session.add(new_url)
+        await session.flush()
         return True
-    except asyncpg.exceptions.UniqueViolationError:
+    except IntegrityError:
+        await session.rollback()
         return False
     except Exception as e:
         logging.error(f"Error creating URL: {str(e)}")
+        await session.rollback()
         raise HTTPException(status_code=500, detail="Error creating URL")
 
 
 async def update_url_target(
-    short_url: str, new_target_url: str, connection: asyncpg.Connection
+    short_url: str, new_target_url: str, session: AsyncSession
 ) -> bool:
     """
     Update an existing short URL mapping.
@@ -122,7 +129,7 @@ async def update_url_target(
     Args:
         short_url: The short URL key to update
         new_target_url: The new target URL
-        connection: Database connection
+        session: Database session
 
     Returns:
         True if URL was updated, False if URL doesn't exist
@@ -137,25 +144,27 @@ async def update_url_target(
         raise UrlValidationError(detail="Target URL cannot be empty")
 
     try:
-        result = await connection.execute(
-            "UPDATE short_urls SET target = $1 WHERE url_key = $2;",
-            new_target_url,
-            short_url,
+        stmt = (
+            update(ShortUrl)
+            .where(ShortUrl.url_key == short_url)
+            .values(target=new_target_url)
         )
-        # Check if any row was updated
-        return "UPDATE 1" in result
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.rowcount > 0
     except Exception as e:
         logging.error(f"Error updating URL: {str(e)}")
+        await session.rollback()
         raise HTTPException(status_code=500, detail="Error updating URL")
 
 
-async def delete_url_target(short_url: str, connection: asyncpg.Connection) -> bool:
+async def delete_url_target(short_url: str, session: AsyncSession) -> bool:
     """
     Delete a short URL mapping.
 
     Args:
         short_url: The short URL key to delete
-        connection: Database connection
+        session: Database session
 
     Returns:
         True if URL was deleted, False if URL doesn't exist
@@ -167,11 +176,11 @@ async def delete_url_target(short_url: str, connection: asyncpg.Connection) -> b
         raise UrlValidationError(detail="Short URL cannot be empty")
 
     try:
-        result = await connection.execute(
-            "DELETE FROM short_urls WHERE url_key=$1;", short_url
-        )
-        # Check if any row was deleted
-        return "DELETE 1" in result
+        stmt = delete(ShortUrl).where(ShortUrl.url_key == short_url)
+        result = await session.execute(stmt)
+        await session.flush()
+        return result.rowcount > 0
     except Exception as e:
         logging.error(f"Error deleting URL: {str(e)}")
+        await session.rollback()
         raise HTTPException(status_code=500, detail="Error deleting URL")

--- a/shortener/database.py
+++ b/shortener/database.py
@@ -1,0 +1,49 @@
+"""Database configuration and session management."""
+
+from typing import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    AsyncEngine,
+    create_async_engine,
+    async_sessionmaker
+)
+from sqlalchemy.pool import NullPool
+
+from shortener.settings import PostgresSettings
+
+
+def create_engine(settings: PostgresSettings) -> AsyncEngine:
+    """Create async SQLAlchemy engine."""
+    return create_async_engine(
+        settings.postgres_dsn,
+        echo=False,
+        poolclass=NullPool,  # Let asyncpg handle pooling
+        pool_pre_ping=True,
+    )
+
+
+def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """Create async session factory."""
+    return async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False
+    )
+
+
+@asynccontextmanager
+async def get_session(
+    session_factory: async_sessionmaker[AsyncSession]
+) -> AsyncGenerator[AsyncSession, None]:
+    """Get database session."""
+    async with session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()

--- a/shortener/views/basic.py
+++ b/shortener/views/basic.py
@@ -2,6 +2,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from shortener.actions import check_db_up
+from shortener.database import get_session
 
 
 async def ping(request: Request) -> JSONResponse:
@@ -23,8 +24,8 @@ async def status(request: Request) -> JSONResponse:
         examples:
             {"db_up": "true"}
     """
-    async with request.app.state.pool.acquire() as connection:
-        db_up_result = await check_db_up(connection)
+    async with get_session(request.app.state.session_factory) as session:
+        db_up_result = await check_db_up(session)
 
     db_up = "true" if db_up_result else "false"
     return JSONResponse({"db_up": db_up})

--- a/shortener/views/redirect.py
+++ b/shortener/views/redirect.py
@@ -4,6 +4,7 @@ from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
 from shortener.actions import get_url_target
+from shortener.database import get_session
 
 
 async def redirect_url(request: Request) -> RedirectResponse:
@@ -22,8 +23,8 @@ async def redirect_url(request: Request) -> RedirectResponse:
     short_url = request.get("path_params", {}).get("short_url")
 
     try:
-        async with request.app.state.pool.acquire() as connection:
-            target_url = await get_url_target(short_url, connection)
+        async with get_session(request.app.state.session_factory) as session:
+            target_url = await get_url_target(short_url, session)
 
         # If valid URL was found, redirect to it
         return RedirectResponse(url=target_url)


### PR DESCRIPTION
- Replace asyncpg raw SQL queries with SQLAlchemy ORM queries
- Add database session management with async SQLAlchemy
- Update all views to use SQLAlchemy sessions
- Update tests to mock SQLAlchemy sessions

Co-Authored-By: Claude <noreply@anthropic.com>
